### PR TITLE
fix pattern p2ps

### DIFF
--- a/src/main/java/stone/mae2/parts/p2p/PatternP2PPartLogic.java
+++ b/src/main/java/stone/mae2/parts/p2p/PatternP2PPartLogic.java
@@ -9,6 +9,7 @@ import appeng.api.networking.ticking.TickingRequest;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.GenericStack;
 import appeng.helpers.patternprovider.PatternProviderTarget;
+import appeng.helpers.patternprovider.PatternProviderTargetCache;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
@@ -19,14 +20,14 @@ import stone.mae2.MAE2;
 import stone.mae2.bootstrap.MAE2Config.TickRates.TickRate;
 import stone.mae2.parts.p2p.PatternP2PTunnelLogic.Target;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 public class PatternP2PPartLogic implements IGridTickable {
 
   private static final String NBT_SEND_LIST = "sendList";
-  private final Set<GenericStack> sendList = new HashSet<>();
+  // a List, not a Set: two identical stacks are two separate debts
+  private final List<GenericStack> sendList = new ArrayList<>();
   private final PatternP2PPartLogicHost part;
 
   public PatternP2PPartLogic(PatternP2PPartLogicHost part) {
@@ -46,14 +47,20 @@ public class PatternP2PPartLogic implements IGridTickable {
     int ticksSinceLastCall) {
     if (this.sendList.isEmpty())
       return TickRateModulation.SLEEP;
-    PatternProviderTarget target = this.part.getCache().find();
+    if (!this.part.getMainNode().isActive())
+      return TickRateModulation.IDLE;
+    PatternProviderTargetCache cache = this.part.getCache();
+    if (cache == null) {
+      return TickRateModulation.IDLE;
+    }
+    PatternProviderTarget target = cache.find();
     if (target == null) {
       return TickRateModulation.IDLE;
     }
 
     boolean didSomething = false;
 
-    for (var it = sendList.iterator(); it.hasNext();) {
+    for (var it = sendList.listIterator(); it.hasNext();) {
       var stack = it.next();
       var what = stack.what();
       long amount = stack.amount();
@@ -63,7 +70,7 @@ public class PatternP2PPartLogic implements IGridTickable {
         it.remove();
         didSomething = true;
       } else if (inserted > 0) {
-        // it.set(new GenericStack(what, amount - inserted));
+        it.set(new GenericStack(what, amount - inserted));
         didSomething = true;
       }
     }
@@ -79,7 +86,7 @@ public class PatternP2PPartLogic implements IGridTickable {
 
   }
 
-  public boolean isValid() { return this.sendList.isEmpty(); }
+  public boolean isSendListEmpty() { return this.sendList.isEmpty(); }
 
   public void addToSendList(AEKey what, long l) {
     boolean wasEmpty = this.sendList.isEmpty();

--- a/src/main/java/stone/mae2/parts/p2p/PatternP2PTunnelLogic.java
+++ b/src/main/java/stone/mae2/parts/p2p/PatternP2PTunnelLogic.java
@@ -39,7 +39,6 @@ import java.util.Set;
 public class PatternP2PTunnelLogic implements ICraftingMachine {
 
   protected final PatternP2PTunnel tunnel;
-  protected PatternProviderTargetCache caches[];
   protected Set<AEKey> patternInputs;
   private int lastOutputIndex = 0;
 
@@ -68,14 +67,15 @@ public class PatternP2PTunnelLogic implements ICraftingMachine {
     try {
       isRecursive = true;
       List<? extends Target> outputs = tunnel.getPatternTunnelOutputs();
-      if (outputs.size() <= 0)
+      if (outputs.isEmpty())
         return false;
       boolean isExternal = pattern.supportsPushInputsToExternalInventory();
-      int i = lastOutputIndex;
+      int start = this.lastOutputIndex % outputs.size();
+      int i = start;
       do {
         i = (i + 1) % outputs.size();
         Target output = outputs.get(i);
-        if (!output.isValid())
+        if (!output.canAcceptPattern())
           continue;
         ICraftingMachine craftingMachine = ICraftingMachine
           .of(output.level(), output.pos(), output.side(),
@@ -89,11 +89,11 @@ public class PatternP2PTunnelLogic implements ICraftingMachine {
           continue;
         }
 
-          if (isExternal) {
-              if (caches == null || caches.length != outputs.size()) {
-                  refreshOutputs();
-              }
-              final PatternProviderTarget target = caches[i].find();
+        if (isExternal) {
+          PatternProviderTargetCache cache = output.getCache();
+          if (cache == null)
+            continue;
+          final PatternProviderTarget target = cache.find();
           if (target == null
             || shouldBlock(isBlocking, target, this.patternInputs))
             continue;
@@ -109,9 +109,9 @@ public class PatternP2PTunnelLogic implements ICraftingMachine {
             return true;
           }
         }
-      } while (i != lastOutputIndex);
+      } while (i != start);
     } catch (Throwable t) {
-        MAE2.LOGGER.error(t.getLocalizedMessage());
+      MAE2.LOGGER.error("Failed to push a pattern through a pattern p2p", t);
     } finally {
       isRecursive = false;
     }
@@ -133,20 +133,9 @@ public class PatternP2PTunnelLogic implements ICraftingMachine {
             : target.containsPatternInput(inputs));
   }
 
-  // TODO make this more incremental instead of resetting everything on any
-  // change
   public void refreshOutputs() {
-    List<? extends Target> outputs = tunnel.getPatternTunnelOutputs();
-    if (outputs.isEmpty()){
-      this.caches = null;
-      return;
-    }
-    this.caches = new PatternProviderTargetCache[outputs.size()];
-    for (int i = 0; i < this.caches.length; i++) {
-      Target output = outputs.get(i);
-      this.caches[i] = output.getCache();
-    }
-    this.lastOutputIndex = this.lastOutputIndex % outputs.size();
+    int outputCount = tunnel.getPatternTunnelOutputs().size();
+    this.lastOutputIndex = outputCount == 0 ? 0 : this.lastOutputIndex % outputCount;
   }
 
   // TODO make this more incremental instead of resetting everything on any
@@ -241,7 +230,9 @@ public class PatternP2PTunnelLogic implements ICraftingMachine {
       return new PatternProviderTargetCache(this.level(), this.pos(), this.side(), this.source());
     }
 
-    boolean isValid();
+    boolean canAcceptPattern();
+
+    boolean isActive();
 
     void addToSendList(AEKey what, long l);
 

--- a/src/main/java/stone/mae2/parts/p2p/PatternP2PTunnelPart.java
+++ b/src/main/java/stone/mae2/parts/p2p/PatternP2PTunnelPart.java
@@ -1,8 +1,7 @@
 package stone.mae2.parts.p2p;
 
-import appeng.api.implementations.blockentities.ICraftingMachine;
 import appeng.api.implementations.blockentities.PatternContainerGroup;
-import appeng.api.networking.IGridNodeListener;
+import appeng.api.networking.IGridNode;
 import appeng.api.networking.crafting.ICraftingProvider;
 import appeng.api.networking.security.IActionSource;
 import appeng.api.parts.IPart;
@@ -52,11 +51,8 @@ public class PatternP2PTunnelPart extends P2PTunnelPart<PatternP2PTunnelPart>
   public PatternP2PTunnelPart(IPartItem<?> partItem) {
     super(partItem);
     this.source = new MachineSource(this);
-    if (this.isOutput()) {
-      this.logic = null;
-    } else {
-      this.logic = LazyOptional.of(() -> new PatternP2PTunnelLogic(this));
-    }
+    // isOutput() is false because nbt was not read yet
+    this.logic = LazyOptional.of(() -> new PatternP2PTunnelLogic(this));
   }
 
   @Override
@@ -92,7 +88,14 @@ public class PatternP2PTunnelPart extends P2PTunnelPart<PatternP2PTunnelPart>
     }
   }
 
-  public boolean isValid() { return this.partLogic.isValid(); }
+  public boolean canAcceptPattern() {
+    // deliberately the node's isActive(), not the part's: AEBasePart.isActive()
+    // is the visual one and ignores grid booting, so it stays true for the few
+    // ticks between a connection being cut and the repath finishing
+    IGridNode node = this.getGridNode();
+    return node != null && node.isActive()
+      && this.partLogic.isSendListEmpty();
+  }
 
   public void addToSendList(AEKey what, long l) {
     this.partLogic.addToSendList(what, l);
@@ -140,8 +143,7 @@ public class PatternP2PTunnelPart extends P2PTunnelPart<PatternP2PTunnelPart>
   @Override
   public <T> LazyOptional<T> getCapability(Capability<T> capabilityClass) {
     if (this.isActive() && this.getFrequency() != 0) {
-      if (this.logic != null
-        && capabilityClass == Capabilities.CRAFTING_MACHINE)
+      if (capabilityClass == Capabilities.CRAFTING_MACHINE && !this.isOutput())
         return (LazyOptional<T>) logic;
       if (this.isOutput()) {
         PatternP2PTunnelPart provider = this.getInput();

--- a/src/main/java/stone/mae2/parts/p2p/multi/MultiP2PTunnel.java
+++ b/src/main/java/stone/mae2/parts/p2p/multi/MultiP2PTunnel.java
@@ -94,7 +94,7 @@ public abstract class MultiP2PTunnel<T extends MultiP2PTunnel<T, L, P>, L extend
       if (part.hasCustomName()) {
         this.customName = part.getCustomName();
       }
-      inputs.add(this.createLogic(part));
+      inputs.add(logic);
     }
     this.updateTunnels(part.isOutput(), false);
     return logic;
@@ -112,7 +112,9 @@ public abstract class MultiP2PTunnel<T extends MultiP2PTunnel<T, L, P>, L extend
    */
   public boolean removeTunnel(P part) {
     boolean wasIn = false;
-    Optional<L> logic = part.getLogic();
+    // not getLogic(), because it returns an empty optional
+    // in this moment
+    Optional<L> logic = part.getAttachedLogic();
     if (part.isOutput()) {
       this.updateTunnels(true, false);
       if (logic.isPresent())
@@ -236,6 +238,8 @@ public abstract class MultiP2PTunnel<T extends MultiP2PTunnel<T, L, P>, L extend
 
     public Optional<L> getLogic() {
       return this.getFrequency() != 0 && this.isActive() ? this.logic : Optional.empty(); }
+
+    protected Optional<L> getAttachedLogic() { return this.logic; }
 
     protected final L setLogic(L logic) {
       this.logic = Optional.ofNullable(logic);

--- a/src/main/java/stone/mae2/parts/p2p/multi/PatternMultiP2PTunnel.java
+++ b/src/main/java/stone/mae2/parts/p2p/multi/PatternMultiP2PTunnel.java
@@ -2,6 +2,7 @@ package stone.mae2.parts.p2p.multi;
 
 import appeng.api.implementations.blockentities.PatternContainerGroup;
 import appeng.api.networking.IGrid;
+import appeng.api.networking.IGridNode;
 import appeng.api.networking.crafting.ICraftingProvider;
 import appeng.api.networking.security.IActionSource;
 import appeng.api.parts.IPart;
@@ -136,7 +137,7 @@ public class PatternMultiP2PTunnel extends
     }
 
     public <T> LazyOptional<T> getCapability(Capability<T> capabilityClass) {
-      if (capabilityClass == Capabilities.CRAFTING_MACHINE)
+      if (capabilityClass == Capabilities.CRAFTING_MACHINE && !this.part.isOutput())
         return (LazyOptional<T>) LazyOptional
           .of(() -> PatternMultiP2PTunnel.this.logic);
       if (this.part.isOutput()) {
@@ -318,8 +319,13 @@ public class PatternMultiP2PTunnel extends
     }
 
     @Override
-    public boolean isValid() { // TODO Auto-generated method stub
-      return this.partLogic.isValid();
+    public boolean canAcceptPattern() {
+      // The nodes isActive(), not the parts, because
+      // the parts one is the visual state and ignores grid booting,
+      // so it stays true for the few ticks after a connection breaking
+      IGridNode node = this.getGridNode();
+      return node != null && node.isActive()
+        && this.partLogic.isSendListEmpty();
     }
 
     @Override


### PR DESCRIPTION
This PR fixes a few things in pattern p2p tunnels
1. Instead of maintaining our own caches get the output cache from target directly before using it.
2. sendList was a set so a second identical stack was lost, now it's a list instead. Also before when the sendList pushed a stack partially, the remainder was lost. 
3. Fixes a possible infinite loop in outputs round robin.
4. isValid renamed to canAcceptPattern, before it was only checking if the sendList is empty, now it checks if the grid node is active as well. Note that it checks grid node not parts node, becuase parts node is used for visual state and ignores grid booting. 
5. isOutput was always false in constructor because its executed before the NBT is read. Now the logic is created always, and isOutput() is checked after, when something asks for the parts capability. 
6. In multi p2p addTunnel was creating logic twice, second time to add it to inputs, instead of adding the logic created before.
7. removeTunnel was using part.getLogic which returns empty optional when part is inactive, but the part can be inactive when its being removed, so sometimes inputs/outputs wouldnt get cleared. Now it asks for getAttachedLogic, which always returns the parts logic. 
8. logger now prints the whole stacktrace instead when it fails to push a pattern through a p2p.